### PR TITLE
refactor: Remove Enterprise API V1

### DIFF
--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_crud.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_crud.py
@@ -80,6 +80,10 @@ class EnterpriseCatalogCRUDViewSet(BaseViewSet, viewsets.ModelViewSet):
         Returns the queryset corresponding to all catalogs the requesting user has access to.
         """
         all_catalogs = EnterpriseCatalog.objects.all().order_by('created')
+        enterprise_customer = self.request.GET.get('enterprise_customer', False)
+        if enterprise_customer:
+            all_catalogs = all_catalogs.filter(enterprise_uuid=enterprise_customer)
+
         if self.request_action == 'list':
             if not self.admin_accessible_enterprises:
                 return EnterpriseCatalog.objects.none()


### PR DESCRIPTION
Description: create endpoint with transferred data from [edx-enterprise](https://github.com/openedx/edx-enterprise/blob/71d81332dbcf6b183cc7886b85542d53adc39992/enterprise/api/v1/views.py#L1003) which returns the data that these usages

Ref to issue comment: https://github.com/openedx/public-engineering/issues/61#issuecomment-1145086895